### PR TITLE
Блокирующий brakeman в CI: исправлен permit!, разобраны предупреждения

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,8 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      # TODO: убрать --no-exit-on-warn после разбора текущих предупреждений
-      # (permit! в dashboard_controller и EOL Ruby 3.1)
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bundle exec brakeman --no-pager --no-exit-on-warn
+        run: bin/brakeman --no-pager
 
   scan_js:
     runs-on: ubuntu-latest

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -42,7 +42,12 @@ class DashboardController < ApplicationController
   # API эндпоинт для сохранения настроек дашборда
   def save_settings
     begin
-      settings_data = params.require(:settings).permit!.to_h
+      settings_data = params.require(:settings).permit(
+        :refresh_interval,
+        :time_range,
+        displayed_panels: [],
+        layout: { rows: [ { panels: [] } ] }
+      ).to_h
 
       # Сохраняем настройки в базе данных
       dashboard_setting = DashboardSetting.current("default")

--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,43 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.2.2.1 ends on 2026-08-09",
+      "file": "Gemfile.lock",
+      "line": 222,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Rails 7.2 поддерживается до 2026-08-09; апгрейд на Rails 8 — отдельная задача. Занесено 2026-07-14."
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 121,
+      "fingerprint": "edf687f759ec9765bd5db185dbc615c80af77d6e7e19386fc42934e7a80307af",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 3.1.4 ended on 2025-03-31",
+      "file": ".ruby-version",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        1104
+      ],
+      "note": "Ruby 3.1.4 EOL: обновление Ruby требует пересборки Docker-образа и проверки совместимости гемов — запланировано отдельной задачей, не блокируем CI. Занесено 2026-07-14."
+    }
+  ],
+  "brakeman_version": "7.0.0"
+}

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class DashboardControllerTest < ActionDispatch::IntegrationTest
+  test "save_settings persists permitted settings including nested layout" do
+    post save_settings_dashboard_index_url, params: {
+      settings: {
+        refresh_interval: "60s",
+        time_range: "3h",
+        displayed_panels: [ "service-health", "error-rate" ],
+        layout: { rows: [ { panels: [ "service-health" ] }, { panels: [ "error-rate" ] } ] }
+      }
+    }, as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert body["success"]
+    assert_equal "60s", body.dig("settings", "refresh_interval")
+
+    stored = DashboardSetting.current("default").settings
+    assert_equal "3h", stored["time_range"]
+    assert_equal [ { "panels" => [ "service-health" ] }, { "panels" => [ "error-rate" ] } ],
+                 stored.dig("layout", "rows")
+  end
+
+  test "save_settings drops keys outside the permitted list" do
+    post save_settings_dashboard_index_url, params: {
+      settings: {
+        refresh_interval: "30s",
+        malicious_key: "evil",
+        layout: { rows: [ { panels: [ "throughput" ], injected: "evil" } ] }
+      }
+    }, as: :json
+
+    assert_response :success
+    stored = DashboardSetting.current("default").settings
+    assert_not stored.key?("malicious_key")
+    assert_equal [ { "panels" => [ "throughput" ] } ], stored.dig("layout", "rows")
+  end
+end


### PR DESCRIPTION
# Что сделано

Шаг `scan_ruby` в CI ничего не гарантировал: brakeman запускался с `--no-exit-on-warn`, а через binstub скан вообще не выполнялся — `bin/brakeman` добавлял `--ensure-latest`, и brakeman 7.0.0 сразу выходил с exit 5 («не последняя версия»), не проверив ни одного файла.

- **bin/brakeman** — убран `--ensure-latest`: для блокирующего CI он вреден, сборка падала бы при каждом релизе новой версии brakeman независимо от кода.
- **dashboard_controller#save_settings** — `params.require(:settings).permit!` заменён на явный список ключей (`refresh_interval`, `time_range`, `displayed_panels[]`, `layout.rows[].panels[]` — ровно та структура, которую шлёт фронтенд). Закрыто предупреждение Mass Assignment; посторонние ключи больше не попадают в базу.
- **config/brakeman.ignore** — два EOL-предупреждения занесены с обоснованием: Ruby 3.1.4 EOL и Rails 7.2 (поддержка до **2026-08-09** — стоит запланировать апгрейд отдельно).
- **ci.yml** — шаг сведён к `bin/brakeman --no-pager`, убран TODO про `--no-exit-on-warn`: любое новое предупреждение теперь роняет сборку.
- Добавлены тесты на `save_settings`: сохранение разрешённых ключей (включая вложенный layout) и отброс посторонних.

## Тип изменения

- [x] Багфикс
- [ ] Новая функциональность
- [ ] Рефакторинг / техдолг
- [ ] Документация
- [x] CI / инфраструктура

## Как проверить

1. `docker run --rm -v $(pwd):/app -w /app dashboard:latest bin/brakeman --no-pager` — exit 0, «Security Warnings: 0, Ignored Warnings: 2».
2. `docker compose exec web ash -c "RAILS_ENV=test bin/rails db:prepare && bin/rails test"` — 8 тестов, 0 падений.
3. На дашборде открыть настройки, изменить интервал обновления/панели, сохранить — настройки применяются и переживают перезагрузку страницы (эндпоинт `/dashboard/save_settings` отвечает 200 с отфильтрованными ключами).

## Чек-лист

- [x] Тесты проходят локально (`docker compose exec web bin/rails test`)
- [x] Добавлены/обновлены тесты для новой логики
- [ ] Проверено в браузере, включая навигацию через Turbo — UI не менялся; эндпоинт проверен интеграционно (200, вложенный layout сохраняется, посторонний ключ отбрасывается)
- [ ] README / документация обновлены, если поведение изменилось — пользовательское поведение не менялось

🤖 Generated with [Claude Code](https://claude.com/claude-code)