### PR TITLE
Автоматические релизы и публикация Docker-образа в ghcr.io по тегу

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,6 +42,7 @@
 
 # Ignore development files
 /.devcontainer
+/.claude
 
 # Ignore Docker-related files
 /.dockerignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+# Автоматический релиз по пушу тега vX.Y.Z:
+#   1) сборка Docker-образа и публикация в GitHub Packages (ghcr.io);
+#   2) создание GitHub Release с автогенерированными примечаниями
+#      (список влитых PR между тегами).
+#
+# Как выпустить релиз:
+#   git tag v1.2.3 && git push origin v1.2.3
+
+on:
+  push:
+    tags: [ "v*" ]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build_and_push_image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Генерирует теги образа: v1.2.3 -> 1.2.3, 1.2 и latest
+      # (имя образа приводится к нижнему регистру автоматически)
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  create_release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build_and_push_image
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ COPY Gemfile* ./
 RUN bundle config build.nokogiri --use-system-libraries && \
     bundle install --jobs $(nproc) --retry 3
 
+# Копируем код приложения: образ из ghcr.io самодостаточен.
+# В docker-compose код по-прежнему монтируется томом поверх копии.
+COPY . .
+
 ENV RAILS_ENV=development
 
 EXPOSE 3000


### PR DESCRIPTION
# Что сделано

GitHub сам по себе не создаёт ни Releases, ни Packages — нужен workflow. Этот PR добавляет `.github/workflows/release.yml`: по пушу тега `vX.Y.Z` автоматически:

1. собирается Docker-образ и публикуется в **GitHub Packages**: `ghcr.io/honfred/dashboard_for_metricks_with_ai` с тегами `1.2.3`, `1.2` и `latest` (с кэшем слоёв между сборками);
2. создаётся **GitHub Release** с автогенерированными примечаниями (список влитых PR между тегами).

Сопутствующее:
- **Dockerfile**: добавлен `COPY . .` — публикуемый образ самодостаточен (раньше код только монтировался томом в compose; compose-сценарий не меняется, том перекрывает копию).
- **.dockerignore**: добавлен `/.claude`; секреты (`master.key`, `.env`) были исключены и раньше — в образ не попадают (проверено).

После влития достаточно: `git tag v1.0.0 && git push origin v1.0.0`.

Примечание: первый опубликованный пакет ghcr по умолчанию приватный — если нужен публичный, включается один раз в настройках пакета (Package settings → Change visibility).

## Тип изменения

- [ ] Багфикс
- [ ] Новая функциональность
- [ ] Рефакторинг / техдолг
- [ ] Документация
- [x] CI / инфраструктура

## Как проверить

1. Влить PR, затем `git tag v1.0.0 && git push origin v1.0.0`.
2. В Actions появится запуск «Release»: job сборки образа и job создания релиза.
3. После завершения: релиз — на странице Releases, образ — в Packages; `docker pull ghcr.io/honfred/dashboard_for_metricks_with_ai:1.0.0`.
4. Локальная сборка не менялась по сути: `docker build .` проходит, код в образе, master.key отсутствует (проверено).

## Чек-лист

- [x] Тесты проходят локально (`docker compose exec web bin/rails test`) — код приложения не менялся
- [ ] Добавлены/обновлены тесты для новой логики — новая логика только в CI-workflow
- [ ] Проверено в браузере, включая навигацию через Turbo — UI не затронут
- [ ] README / документация обновлены, если поведение изменилось — инструкция по релизу описана в комментарии workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)